### PR TITLE
Debian Bullseye Python 3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable
+FROM debian:bullseye
 MAINTAINER Johan Lundberg <lundberg@sunet.se>
 
 RUN apt-get update && \


### PR DESCRIPTION
Downgrade to Debian Bullseye to fix Python 3.11 issues with old Django version